### PR TITLE
Bump databus version

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -7,7 +7,7 @@ cd build
 
 git clone --single-branch --branch databus https://github.com/jupyterlab/jupyterlab.git
 cd jupyterlab
-git checkout 7014fba58
+git checkout c218a0dfa
 cd ..
 
 git clone https://github.com/jupyterlab/jupyterlab-metadata-service.git

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -7,7 +7,7 @@ cd build
 
 git clone --single-branch --branch databus https://github.com/jupyterlab/jupyterlab.git
 cd jupyterlab
-git checkout a663c8305
+git checkout 7014fba58
 cd ..
 
 git clone https://github.com/jupyterlab/jupyterlab-metadata-service.git

--- a/databus.yml
+++ b/databus.yml
@@ -1,0 +1,6 @@
+version: "1"
+datasets:
+    - url: "file:///data/adrf-000005.csv"
+    - url: "file:///data/adrf-000014.csv"
+    - url: "file:///data/adrf-000015.csv"
+    - url: "https://raw.githubusercontent.com/cs109/2014_data/master/countries.csv"


### PR DESCRIPTION
This should support importing a `databus.yml` file to register a set of datasets.

The inserted snippet should also correctly insert a relative path.

I am testing it here: https://mybinder.org/v2/gh/jupytercalpoly/rich-context-demo/saulshanabrook-patch-1?urlpath=lab/tree/src/Notebook.ipynb